### PR TITLE
ci: añade uv lock a pre-commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.py[cod]
 *$py.class
 
+.pixi/
 .vscode/
 
 # C extensions
@@ -157,3 +158,4 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+node_modules

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,3 +58,9 @@ repos:
     hooks:
       - id: prettier
         types_or: [markdown, yaml]
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.4.9
+    hooks:
+      # Update the uv lockfile
+      - id: uv-lock


### PR DESCRIPTION
Esto asegura que el `uv.lock` está siempre actualizado, por si de casualidad se editara el `pyproject.toml` a mano sin usar `uv add` o `uv remove`

Closes #55 