### PR TITLE
fix: actualiza conf de Ruff en VSCode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,8 +9,8 @@
     },
     "notebook.formatOnSave.enabled": true,
     "notebook.codeActionsOnSave": {
-        "source.fixAll.ruff": "explicit",
-        "source.organizeImports.ruff": "explicit"
+        "notebook.source.fixAll": "explicit",
+        "notebook.source.organizeImports": "explicit"
     },
     "python.testing.unittestEnabled": false,
     "python.testing.pytestEnabled": true,


### PR DESCRIPTION
Ver [FAQ](https://docs.astral.sh/ruff/faq/#source-code-actions-in-notebooks) y [configuración recomendada](https://github.com/astral-sh/ruff-vscode), aunque estoy tentado de eliminarlo del template, siempre se queda en todos los repos