### PR TITLE
feat: add vulnerability audit workflow (PoC)

### DIFF
--- a/.github/workflows/vulnerability-audit.yml
+++ b/.github/workflows/vulnerability-audit.yml
@@ -10,10 +10,6 @@ on:
     paths:
       - "uv.lock"
       - "pyproject.toml"
-  # Temporary: trigger on push to test the workflow
-  push:
-    branches:
-      - feature/vulnerability-audit-poc
 
 jobs:
   # Approach 1: pip-audit (PyPA official tool)

--- a/.github/workflows/vulnerability-audit.yml
+++ b/.github/workflows/vulnerability-audit.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - "uv.lock"
       - "pyproject.toml"
+  # Temporary: trigger on push to test the workflow
+  push:
+    branches:
+      - feature/vulnerability-audit-poc
 
 jobs:
   # Approach 1: pip-audit (PyPA official tool)
@@ -32,7 +36,7 @@ jobs:
 
   # Approach 2: uv-secure (reads uv.lock directly)
   # Pros: fast (no install needed), reads uv.lock natively, supports severity filtering
-  # Cons: newer/less established tool
+  # Cons: newer/less established, community tool
   uv-secure:
     runs-on: ubuntu-latest
     steps:
@@ -41,3 +45,15 @@ jobs:
         uses: astral-sh/setup-uv@v7
       - name: Run uv-secure
         run: uvx uv-secure uv.lock
+
+  # Approach 3: uv audit (native uv command, still in preview as of 0.11.2)
+  # Pros: native to uv (no extra tools), reads uv.lock directly, uses OSV database
+  # Cons: requires --preview flag, may change before stable
+  uv-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Run uv audit
+        run: uv audit --preview

--- a/.github/workflows/vulnerability-audit.yml
+++ b/.github/workflows/vulnerability-audit.yml
@@ -10,6 +10,10 @@ on:
     paths:
       - "uv.lock"
       - "pyproject.toml"
+  # Temporary: trigger on push to test the workflow
+  push:
+    branches:
+      - feature/vulnerability-audit-poc
 
 jobs:
   # Approach 1: pip-audit (PyPA official tool)

--- a/.github/workflows/vulnerability-audit.yml
+++ b/.github/workflows/vulnerability-audit.yml
@@ -1,0 +1,43 @@
+name: Vulnerability Audit
+
+on:
+  schedule:
+    # Run weekly on Mondays at 9:00 UTC
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+  # Also run on PRs that change dependencies
+  pull_request:
+    paths:
+      - "uv.lock"
+      - "pyproject.toml"
+
+jobs:
+  # Approach 1: pip-audit (PyPA official tool)
+  # Audits the installed environment after uv sync.
+  # Pros: official PyPA tool, well-maintained, GitHub Action available
+  # Cons: requires installing deps first (slower), doesn't read uv.lock directly
+  pip-audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: uv.lock
+      - name: Install the project
+        run: uv sync --locked --dev --all-extras
+      - name: Run pip-audit
+        run: uv run --with pip-audit pip-audit --strict --vulnerability-service osv --desc
+
+  # Approach 2: uv-secure (reads uv.lock directly)
+  # Pros: fast (no install needed), reads uv.lock natively, supports severity filtering
+  # Cons: newer/less established tool
+  uv-secure:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+      - name: Run uv-secure
+        run: uvx uv-secure uv.lock

--- a/.github/workflows/vulnerability-audit.yml
+++ b/.github/workflows/vulnerability-audit.yml
@@ -13,22 +13,17 @@ on:
 
 jobs:
   # Approach 1: pip-audit (PyPA official tool)
-  # Audits the installed environment after uv sync.
-  # Pros: official PyPA tool, well-maintained, GitHub Action available
-  # Cons: requires installing deps first (slower), doesn't read uv.lock directly
+  # Exports uv.lock to requirements format and pipes it into pip-audit (no install needed).
+  # Pros: official PyPA tool, well-maintained, no env install required
+  # Cons: requires export step, doesn't read uv.lock directly
   pip-audit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Install uv and Python
+      - name: Install uv
         uses: astral-sh/setup-uv@v7
-        with:
-          enable-cache: true
-          cache-dependency-glob: uv.lock
-      - name: Install the project
-        run: uv sync --locked --dev --all-extras
       - name: Run pip-audit
-        run: uv run --with pip-audit pip-audit --strict --vulnerability-service osv --desc
+        run: uv export --locked --no-hashes | uvx pip-audit -r /dev/stdin --strict --vulnerability-service osv --desc
 
   # Approach 2: uv-secure (reads uv.lock directly)
   # Pros: fast (no install needed), reads uv.lock natively, supports severity filtering


### PR DESCRIPTION
## Summary
- Adds a GitHub Actions workflow that audits dependencies for known vulnerabilities
- Includes three approaches for comparison:
  1. **pip-audit** (PyPA official) — exports `uv.lock` to requirements format and pipes it into pip-audit (no install needed)
  2. **uv-secure** — reads `uv.lock` directly, no install needed
  3. **uv audit** — native `uv` command (preview), reads `uv.lock` directly using the OSV database
- Runs weekly on Mondays, on `workflow_dispatch`, and on PRs that change `uv.lock` or `pyproject.toml`

## Test results
All three tools ran successfully and detected the same vulnerability:
- `pygments 2.19.2` — CVE-2026-4539 (ReDoS)

| | pip-audit | uv-secure | uv audit |
|---|---|---|---|
| Runtime | ~16s | ~5s | ~2s |
| uv.lock support | Indirect (export step) | Native | Native |
| Maintainer | PyPA (official) | Community | Astral (uv) |
| Notes | Well-established | Fast, supports severity filtering | Requires `--preview` flag, may change before stable |

## Next steps
- Decide which tool to keep (recommendation: uv-secure for simplicity)
- Add to `python-copier-template` and roll out to all repos
- Consider `continue-on-error: true` for scheduled runs to avoid noisy failures