### PR TITLE
chore(ci): run Security Updates weekly instead of daily

### DIFF
--- a/.github/workflows/security-updates.yml
+++ b/.github/workflows/security-updates.yml
@@ -2,7 +2,7 @@ name: Security Updates
 
 on:
   schedule:
-    - cron: "30 3 * * *"
+    - cron: "37 3 * * 1"
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Changes the `Security Updates` workflow from a daily schedule (03:30 UTC) to a weekly one (Mondays 03:37 UTC). Exactly one line changes; nothing else in the file is touched.

```diff
-    - cron: "30 3 * * *"
+    - cron: "37 3 * * 1"
```

## Why

- This repo runs the workflow ~29x/month at ~1.0 billed minute per run. Across the 10 affected repos that is **~145 billed min/month, essentially all of it per-job minimum-minute rounding** — the job itself finishes in well under 60s.
- Komorebi-AI hit **100% of its ~3,200 min/month Actions allowance in July** (3,212 min used). This is one of three consolidations to get back under it.
- Reducing the detection cadence is safe here because **detection was never the bottleneck — merging is.** `asistente-licitaciones` PR #405 has been open since 27 June carrying fixes for 32 high-severity alerts, and its oldest open alert dates from 14 April (~108 days). Going from 1-day to 7-day detection latency is immaterial next to a ~100-day merge latency.

- This repo is included deliberately: it is the scaffold other repos are generated from, so changing it here stops newly generated repos inheriting the daily schedule.

## This does not weaken the fix path

Only the cadence changes. 103 of 104 open alerts org-wide carry a verified patched version, and for those the bot passes `--exclude-newer-package <pkg>=<now>`, which bypasses the repo's `exclude-newer = "7 days"` uv policy. `workflow_dispatch` is also untouched, so the workflow can still be run on demand at any time.

The `:37` minute (rather than `:30`) is deliberate — GitHub delays scheduled workflows that pile onto the `:00`/`:30` marks.

https://claude.ai/code/session_01Xke8d7un3d7fBQcLHrkWr8
